### PR TITLE
Now made the 'black-hole cond-expand feature appear in ##cond-expand-features .

### DIFF
--- a/build.scm
+++ b/build.scm
@@ -49,6 +49,8 @@
         (lib . ,lib-module-resolver)
         (std . ,(package-module-resolver "~~lib/modules/std"))))
 
+;; Add cond-expand feature by default
+(set! ##cond-expand-features (cons 'black-hole ##cond-expand-features))
 
 ;; ---------- Add the hooks =) ----------
 

--- a/hygiene.scm
+++ b/hygiene.scm
@@ -1607,7 +1607,7 @@
         (lambda clauses
           (cond-expand-build source
                              clauses
-                             (cons 'black-hole ##cond-expand-features))))
+                             ##cond-expand-features)))
        env)
       
       ))


### PR DESCRIPTION
Thanks to Alvaro for the idea.

This is supposed to be a commit of three rows as seen in the commit on 
https://github.com/m-i-k-a-e-l/blackhole/commit/0c2e8760ca37b16fbd0169683c6fd8bcf3242960 .
The diff ("files changed") I see here though shows a re-commit of the previous commit too. I suppose it doesn't hurt, though, it's not in the scope and intend of this pull request.
