### PR TITLE
Change to follow interface change in Gambit-C 4.6.6

### DIFF
--- a/src/compile-load.scm
+++ b/src/compile-load.scm
@@ -227,7 +227,7 @@
           (set! prev-hook c#expand-source)
           (set! c#expand-source hook))
         (lambda ()
-          (compile-file-to-c "/dev/null"
+          (compile-file-to-target "/dev/null"
                              output: fn
                              options: options))
         (lambda ()


### PR DESCRIPTION
To follow Gambit-C 4.6.6, replacing compile-file-to-c by compile-file-to-target;
For more details look at: following gambit-c changelist:

Commit 095a64308c3edcaecf7ca077b3f5405c33d10f83 [095a643]
Parents: fbb1e789ca
Author: Marc Feeley feeley@iro.umontreal.ca
Date: 17 mai 2012 19:02:02 CEST

Prepare for new back-ends (gsc option -target). Replace compile-file-to-c by compile-file-to-target. Preliminary version of a universal back-end to generate JavaScript, Python, PHP, etc.
