### PR TITLE
Fix lib path

### DIFF
--- a/src/blackhole.scm
+++ b/src/blackhole.scm
@@ -1,6 +1,6 @@
 (##namespace ("bh#"))
 
-(##include "~~/lib/gambit#.scm")
+(##include "~~lib/gambit#.scm")
 
 (declare (standard-bindings)
 	 (extended-bindings)


### PR DESCRIPTION
The proper syntax for lib is "~~lib/...", not "~~/lib".  The later
only works if the file in question is in $prefix/lib, which is not
always the case.
